### PR TITLE
Remove #[used] attributes

### DIFF
--- a/orbit-app/src/lib.rs
+++ b/orbit-app/src/lib.rs
@@ -27,7 +27,7 @@ feature_mod!("ch32x035", pub, blinky_x035);
 #[macro_export]
 macro_rules! app_stack {
     ($size:expr, $app_name:expr) => {
-        #[used]
+        #[allow(unused)]
         #[link_section = concat!(".", $app_name, ".bss")]
         pub static mut STACK: [usize; $size] = [0; $size];
     };

--- a/orbit-common-proc-macro/src/lib.rs
+++ b/orbit-common-proc-macro/src/lib.rs
@@ -144,7 +144,6 @@ pub fn orbit_app(attr: TokenStream, item: TokenStream) -> TokenStream {
             port::{RINGBUF_SIZE, RingbufType, ringbuf::RingBuf, message::Message},
         };
 
-        #[used]
         #[unsafe(no_mangle)]
         #[unsafe(link_section=concat!(".", #app_name, ".bss.struct"))]
         static mut #static_name: MaybeUninit<#struct_name #ty_static_generics> = MaybeUninit::uninit();


### PR DESCRIPTION
Behavior in https://github.com/Wooker/orbit/issues/1 is caused by the use of `#[used]` attribute. Due to its presence the compiler keep applications STACK and STRUCT static instances.

Another solution could be to use the `/DISCARD/` section in `orbit-bin/link.x` to discard .bss sections of unused applications:
```ls
    /DISCARD/ : {
        *(.*.bss)
        *(.*.bss.*)
    }
```