### PR TITLE
Remove applications' .bss sections from Flash memory and allocate application structss dynamically

### DIFF
--- a/orbit-app/src/application.rs
+++ b/orbit-app/src/application.rs
@@ -1,10 +1,10 @@
 use orbit_kernel::application::Context;
-// const STACK_SIZE: u32 = 1024;
 
 pub trait Application {
     fn main(&mut self);
     #[allow(unsafe_code)]
     fn context(&self) -> Context;
+    fn stack_size() -> usize;
     extern "C" fn ecall();
 }
 

--- a/orbit-app/src/lib.rs
+++ b/orbit-app/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod application;
 pub mod service;
 
-use orbit_common::feature_mod;
+use orbit_common::{app_stack, feature_mod};
 use orbit_kernel::kernel::Kernel;
 
 #[allow(unsafe_code)]
@@ -23,15 +23,6 @@ feature_mod!("ch32v003", pub, blinky_v003);
 feature_mod!("ch32x035", pub, blinky_x035);
 
 /// Macros
-
-#[macro_export]
-macro_rules! app_stack {
-    ($size:expr, $app_name:expr) => {
-        #[allow(unused)]
-        #[link_section = concat!(".", $app_name, ".bss")]
-        pub static mut STACK: [usize; $size] = [0; $size];
-    };
-}
 
 #[macro_export]
 macro_rules! syscall {

--- a/orbit-app/src/system_num_ports.rs
+++ b/orbit-app/src/system_num_ports.rs
@@ -3,7 +3,7 @@ use orbit_kernel::syscall::SysCall;
 
 use crate::{app_stack, syscall};
 
-app_stack!(32, "systemnumports");
+app_stack!(64, "systemnumports");
 
 #[orbit_app()]
 pub struct SystemNumPorts {}

--- a/orbit-arch/src/riscv32/mod.rs
+++ b/orbit-arch/src/riscv32/mod.rs
@@ -6,7 +6,7 @@ pub use qingke::*;
 #[cfg(any(feature = "qingke_v4", feature = "qingke_v2"))]
 mod qingke_cpu;
 #[cfg(any(feature = "qingke_v4", feature = "qingke_v2"))]
-pub use qingke_cpu::{Core, PMP};
+pub use qingke_cpu::{delay, Core, PMP};
 // #[cfg(any(feature = "qingke_v4", feature = "qingke_v2"))]
 // pub use qingke_rt::entry;
 

--- a/orbit-arch/src/riscv32/qingke_cpu.rs
+++ b/orbit-arch/src/riscv32/qingke_cpu.rs
@@ -11,6 +11,8 @@ use qingke::riscv::{
     result::{Error as RiscvError, Result},
 };
 
+pub use qingke::riscv::asm::delay;
+
 #[cfg(feature = "qingke_v4")]
 pub const PMP: usize = 4;
 

--- a/orbit-bin/build.rs
+++ b/orbit-bin/build.rs
@@ -36,14 +36,13 @@ fn link_script_from_feature(feature: &String, script_name: &str) -> Vec<u8> {
     buf
 }
 
-fn write_linker_script(out: &PathBuf, name: String, flash: bool) {
-    let (content, dest_path) = if flash == true {
-        (
-            format!(
-                "
+fn write_linker_script(out: &PathBuf, name: String) {
+    let (content, dest_path) = (
+        format!(
+            "
 SECTIONS
 {{
-    .text.apps.{0} : ALIGN(4)
+    .apps.{0}.text : ALIGN(4)
     {{
         PROVIDE( _app_{0}_text_start = .);
         *(.{0}.text)
@@ -64,39 +63,10 @@ SECTIONS
     }} >FLASH
 }}
 ",
-                name
-            ),
-            Path::new(&out).join(format!("app-{}-flash-link.x", name)),
-        )
-    } else {
-        (
-            format!(
-                "
-SECTIONS
-{{
-    .bss.apps.{0} : ALIGN(4)
-    {{
-        PROVIDE( _app_{0}_bss_start = .);
-        . = ALIGN(4);
-        PROVIDE( _app_{0}_bss_struct = .);
-        *(.{0}.bss.struct);
-
-        *(.{0}.bss);
-        PROVIDE( _app_{0}_bss_end = .);
-    }} >RAM AT>FLASH
-
-    .stack.apps.{0} : ALIGN(4)
-    {{
-        *(.{0}.stack);
-        PROVIDE( _{0}_stack_top = .);
-    }} >RAM AT>FLASH
-}}
-",
-                name
-            ),
-            Path::new(&out).join(format!("app-{}-ram-link.x", name)),
-        )
-    };
+            name
+        ),
+        Path::new(&out).join(format!("app-{}-flash-link.x", name)),
+    );
     write(dest_path, content).expect("Failed to write to applicatoin linker script");
 }
 
@@ -166,8 +136,7 @@ fn main() {
                 .collect::<Vec<String>>();
             p!("Apps: {:?}", names);
             for name in names {
-                write_linker_script(app_out, name.clone(), true);
-                write_linker_script(app_out, name, false);
+                write_linker_script(app_out, name.clone());
             }
         } else {
             p!("Apps empty: []");

--- a/orbit-bin/link.x
+++ b/orbit-bin/link.x
@@ -22,7 +22,6 @@ SECTIONS
 
     .kernel.stack ORIGIN(RAM) + LENGTH(RAM) : ALIGN(4)
     {
-        *(.kernel.stack);
         PROVIDE( _stack_top = .);
     } >RAM
 }

--- a/orbit-common-proc-macro/src/lib.rs
+++ b/orbit-common-proc-macro/src/lib.rs
@@ -46,8 +46,26 @@ pub fn orbit_app(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let static_name = format_ident!("{}", struct_name.to_string().to_uppercase());
 
+    let existing_fields_default = match struct_item.fields {
+        Fields::Named(ref fields_named) => fields_named.named.iter().map(|f| {
+            let name = f.ident.as_ref().expect("Expected named field");
+            let ty = &f.ty;
+            quote! {
+                #name: <#ty>::default()
+            }
+        }),
+        _ => {
+            return syn::Error::new_spanned(
+                struct_item.fields.clone(),
+                "Only structs with named fields are supported",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
     let existing_fields = match struct_item.fields {
-        Fields::Named(fields_named) => fields_named.named,
+        Fields::Named(ref fields_named) => &fields_named.named,
         _ => {
             return syn::Error::new_spanned(
                 struct_item.fields.clone(),
@@ -65,61 +83,20 @@ pub fn orbit_app(attr: TokenStream, item: TokenStream) -> TokenStream {
             #lower: MaybeUninit<Claimed<'static, #i>>,
         }
     });
-
-    let app_text_start = Ident::new(
-        &format!("_app_{}_text_start", app_name.value()),
-        struct_name.span(),
-    );
-    let app_text_end = Ident::new(
-        &format!("_app_{}_text_end", app_name.value()),
-        struct_name.span(),
-    );
-    let app_bss_start = Ident::new(
-        &format!("_app_{}_bss_start", app_name.value()),
-        struct_name.span(),
-    );
-    let app_bss_end = Ident::new(
-        &format!("_app_{}_bss_end", app_name.value()),
-        struct_name.span(),
-    );
-    let app_text_main = Ident::new(
-        &format!("_app_{}_text_main", app_name.value()),
-        struct_name.span(),
-    );
-    let app_bss_struct = Ident::new(
-        &format!("_app_{}_bss_struct", app_name.value()),
-        struct_name.span(),
-    );
+    let peripherals_default = args.iter().map(|i| {
+        let lower = format_ident!("{}", i.to_string().to_lowercase());
+        quote! {
+            #lower: MaybeUninit::uninit()
+        }
+    });
 
     let _init = quote! {
         #[inline(never)]
         #[unsafe(link_section = concat!(".", #app_name, ".text"))]
         pub fn _init(&mut self) {
-            unsafe extern "C" {
-                static #app_text_start: usize;
-                static #app_text_end: usize;
-                static #app_bss_start: usize;
-                static #app_bss_end: usize;
-                static #app_text_main: usize;
-                static #app_bss_struct: usize;
-            }
-
-            let provides = unsafe {
-                &#app_text_end as *const usize as usize
-                    | &#app_text_start as *const usize as usize
-                    | &#app_text_end as *const usize as usize
-                    | &#app_bss_start as *const usize as usize
-                    | &#app_bss_end as *const usize as usize
-                    | &#app_text_main as *const usize as usize
-                    | &#app_bss_struct as *const usize as usize
-            };
-
             self.context = Context::new();
-            self.context.t0 = provides;
-            compiler_fence(core::sync::atomic::Ordering::SeqCst);
-
             self.context.t0 = 0;
-            self.context.sp = unsafe { STACK.last().unwrap_unchecked() as *const usize as usize + 0x4 };
+            self.context.sp = self as *const Self as usize + core::mem::size_of::<Self>() + Self::stack_size();
             self.context.gp = &self.context as *const Context as usize;
             self.context.ra = Self::ecall as *const fn() as usize;
 
@@ -151,13 +128,21 @@ pub fn orbit_app(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[repr(C,align(4))]
         #(#attributes)*
         pub struct #struct_name #ty_generics {
-            pub context: Context,
+            context: Context,
             pub _buf: RingBuf<RINGBUF_SIZE, RingbufType>,
             #existing_fields
             #(#peripherals)*
         }
 
         impl #impl_generics #struct_name #ty_generics {
+            pub fn new() -> Self {
+                Self {
+                    context: Context::new(),
+                    _buf: RingBuf::new(0),
+                    #(#existing_fields_default),*
+                    #(#peripherals_default),*
+                }
+            }
             #_init
         }
 
@@ -178,6 +163,12 @@ pub fn orbit_app(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[unsafe(link_section = concat!(".", #app_name, ".text"))]
             fn context(&self) -> Context {
                 self.context
+            }
+
+            #[inline(always)]
+            #[unsafe(link_section = concat!(".", #app_name, ".text"))]
+            fn stack_size() -> usize{
+                stack_size
             }
 
             #[unsafe(naked)]
@@ -270,52 +261,60 @@ pub fn orbit_main_attribute(attr: TokenStream, _item: TokenStream) -> TokenStrea
     let attr_args = parse_macro_input!(attr as OrbitMainArgs);
     let args: Vec<Ident> = attr_args.structs.into_iter().collect();
 
-    let statics = args
-        .iter()
-        .map(|s| {
-            let struct_upper = format_ident!("{}", s.to_string().to_uppercase());
-            quote! {
-                static mut #struct_upper: #s;
-            }
-        })
-        .collect::<Vec<proc_macro2::TokenStream>>();
-
     let inits = args
         .iter()
         .enumerate()
         .map(|(i, s)| {
-            let struct_upper = format_ident!("{}", s.to_string().to_uppercase());
             let struct_lower = format_ident!("{}", s.to_string().to_lowercase());
+            let struct_lower_ptr = format_ident!("{}_ptr", struct_lower);
             quote! {
-                #struct_upper.init();
-                KERNEL.add_application(
+                let #struct_lower_ptr = next_addr as *mut MaybeUninit<#s>;
+                unsafe {
+                    (*#struct_lower_ptr).as_mut_ptr().write(
+                        #s::new()
+                    )
+                };
+                let #struct_lower = unsafe { &mut *(*(#struct_lower_ptr)).assume_init_mut() };
+                #struct_lower.init();
+                kernel.add_application(
                     #i,
                     stringify!(#struct_lower),
-                    unsafe { &#struct_upper as *const #s as usize },
+                    next_addr, //unsafe { &#s as *const #s as usize },
                     #s::main as usize,
                     #s::interrupt as usize,
-                    unsafe { &mut (&mut #struct_upper).context as *mut _ },
+                    unsafe { &mut (#struct_lower).context() as *mut _ },
                     // #struct_upper.buf(),
-                    unsafe { &mut (&mut #struct_upper)._buf as *mut _ },
+                    unsafe { &mut (#struct_lower)._buf as *mut _ },
                 );
+                next_addr += core::mem::size_of::<#s>() + #s::stack_size();
             }
         })
         .collect::<Vec<proc_macro2::TokenStream>>();
 
     let expanded = quote! {
-        unsafe extern "Rust" {
-            static mut KERNEL: Kernel<'static>;
-            #(#statics)*
+        use core::mem::MaybeUninit;
+        use orbit_kernel::application::Context;
+        use orbit_kernel::port::ringbuf::RingBuf;
+
+        unsafe extern "C" {
+            static _kernel_start: usize;
         }
 
         #[unsafe(no_mangle)]
         #[unsafe(link_section = ".text.bin")]
         unsafe fn main() {
-            KERNEL.clock.freeze();
+            let kernel_ptr = unsafe { &_kernel_start as *const usize as *mut MaybeUninit<Kernel> };
+            unsafe { (*kernel_ptr).as_mut_ptr().write(Kernel::new()) };
+            let kernel = unsafe { &mut *(*kernel_ptr).assume_init_mut() };
+
+            // Use `kernel` as a `&mut Kernel` here
+            kernel.clock.freeze();
+
+            let mut next_addr = kernel_ptr as usize + core::mem::size_of::<Kernel>();
 
             #(#inits)*
 
-            KERNEL.initialize();
+            kernel.initialize();
         }
     };
 
@@ -382,10 +381,7 @@ pub fn define_ports(input: TokenStream) -> TokenStream {
         pub struct PortInterruptTable(pub [(*const PortPeripheral, usize, PortKinds); PORT_NUM]);
         unsafe impl Sync for PortInterruptTable {}
 
-        #[used]
-        #[unsafe(no_mangle)]
-        #[unsafe(link_section = ".kernel.bss")]
-        pub static PORT_INTERRUPTS: PortInterruptTable =
+        pub const PORT_INTERRUPTS: PortInterruptTable =
             PortInterruptTable([#(#ptrs),*]);
     };
 

--- a/orbit-common/src/lib.rs
+++ b/orbit-common/src/lib.rs
@@ -64,3 +64,10 @@ macro_rules! feature_mod_use_mutual {
         }
     };
 }
+
+#[macro_export]
+macro_rules! app_stack {
+    ($size:expr, $app_name:expr) => {
+        const stack_size: usize = $size;
+    };
+}

--- a/orbit-kernel/kernel.x
+++ b/orbit-kernel/kernel.x
@@ -2,7 +2,7 @@ ENTRY(_start)
 
 SECTIONS
 {
-    .text.kernel : ALIGN(4)
+    .kernel.text : ALIGN(4)
     {
         /* *(.vector_table.interrupts); */
         /* . = 0x3fc; */
@@ -47,10 +47,9 @@ SECTIONS
 
     .kernel.bss : ALIGN(4)
     {
-        PROVIDE( _kernel_struct = .);
-        *(.kernel.bss);
-        *(.bss .bss.*);
-        *(.sbss .sbss.*);
+        *(.bss.* .sbss.*);
+        *(.kernel.ports.bss);
+        . = ALIGN(4);
+        PROVIDE( _kernel_start = .);
     } >RAM AT>FLASH
-
 }

--- a/orbit-kernel/src/kernel.rs
+++ b/orbit-kernel/src/kernel.rs
@@ -30,11 +30,6 @@ pub static KERNEL_MAJOR: u8 = 0;
 #[link_section = ".kernel.rodata"]
 pub static KERNEL_MINOR: u8 = 1;
 
-#[used]
-#[no_mangle]
-#[link_section = ".kernel.bss"]
-pub static mut KERNEL: MaybeUninit<Kernel> = MaybeUninit::uninit();
-
 #[repr(C, align(4))]
 pub struct Kernel<'k> {
     context: Context,
@@ -206,6 +201,7 @@ impl<'k> Kernel<'k> {
     pub fn interrupt_handler(&mut self) -> RunApplication {
         let code = orbit_arch::riscv::register::mcause::read().code();
 
+        // Check if it's a port interrupt
         if let Some((index, _)) = PORT_INTERRUPTS
             .0
             .iter()
@@ -216,6 +212,7 @@ impl<'k> Kernel<'k> {
             // is invoked
             self.port_handler(index)
         } else {
+            // TODO: invoke app interrupt
             RunApplication::None
         }
     }

--- a/orbit-kernel/src/lib.rs
+++ b/orbit-kernel/src/lib.rs
@@ -55,7 +55,7 @@ _start:
     "la ra, initialize_finish",
     // Set mscratch
     "
-    la gp, _kernel_struct;
+    la gp, _kernel_start;
     csrw mscratch, gp;
     ",
     // Set mtvec

--- a/orbit-kernel/src/port/mod.rs
+++ b/orbit-kernel/src/port/mod.rs
@@ -1,6 +1,5 @@
 #![allow(unused)]
 
-use crate::kernel::KERNEL;
 use chip::PortPeripheral;
 use orbit_arch::interface::timer::Timer;
 use orbit_common::{feature_mod_use, feature_mod_use_mutual};
@@ -71,7 +70,7 @@ impl<'p> Port<'p> {
         for i in 5..=9 {
             self.peripheral.clear_int(i);
         }
-        unsafe { KERNEL.assume_init_read().core.timer.delay(250) };
+        orbit_arch::delay(250);
     }
 
     #[inline(never)]

--- a/orbit-kernel/src/port/ringbuf.rs
+++ b/orbit-kernel/src/port/ringbuf.rs
@@ -8,6 +8,7 @@ where
 impl TraitBound for u8 {}
 
 #[derive(Clone, Copy)]
+#[repr(C)]
 pub struct RingBuf<const SIZE: usize, T: TraitBound> {
     pub start: usize,
     pub end: usize,


### PR DESCRIPTION
Fixes #3 .

Some changes needed to make it work:
- Add `#[repr(C)]` for RingBuf.
- Change stack size of SystemNumPort from `32` to `64`.

Otherwise, application buffers were affected and resulted in wrong data transferred as application return values.